### PR TITLE
[fix] Direct buffer.write fails on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,5 +30,6 @@ test/logfile.txt: test/test1.py streamcapture/__init__.py Makefile
 	cd test && ../scripts/python test3.repeating.py
 	cd test && ../scripts/python test4.fast_open_close.py
 	cd test && ../scripts/python test5.multi_capture_to_same_buffer.py
+	cd test && ../scripts/python test6.buffer_write.py
 
 test: test/logfile.txt

--- a/streamcapture/__init__.py
+++ b/streamcapture/__init__.py
@@ -196,7 +196,7 @@ class StreamCapture:
 		self.monkeypatch = platform.system()=='Windows' if monkeypatch is None else monkeypatch
 		if self.monkeypatch:
 			self.oldwrite = stream.write
-			stream.write = lambda z: os.write(stream.fileno(),z.encode() if hasattr(z,'encode') else z)
+			stream.buffer.write = lambda z: os.write(stream.fileno(), z)
 	def close(self):
 		"""When you want to "uncapture" a stream, use this method."""
 		self.stream.flush()

--- a/test/test3.repeating.py
+++ b/test/test3.repeating.py
@@ -11,8 +11,9 @@ for i in range(10):
     try:
         print('1234')
         time.sleep(1)
-        if buffer.getvalue() != '1234\n'.encode():
-            raise RuntimeError(f'Test failed. Found: {buffer.getvalue().decode()}')
+        buffer_str = buffer.getvalue().decode().rstrip()
+        if buffer_str != '1234':
+            raise RuntimeError(f'Test failed. Found: {buffer_str}')
     finally:
         stdout_capturer.close()
         buffer.close()

--- a/test/test6.buffer_write.py
+++ b/test/test6.buffer_write.py
@@ -1,0 +1,17 @@
+import io
+import sys
+
+import streamcapture
+
+
+buffer = io.BytesIO()
+try:
+    with streamcapture.StreamCapture(sys.stdout, buffer) as stdout_capturer:
+        sys.stdout.buffer.write("1234\n".encode())
+
+    buffer_str = buffer.getvalue().decode().rstrip()
+    if buffer_str != '1234':
+        raise RuntimeError(f'Test failed. Found: {buffer_str}')
+finally:
+    stdout_capturer.close()
+    buffer.close()


### PR DESCRIPTION
On windows, the monkey patch does not function properly.
Using `sys.stdout.buffer.write` can result in an `OSError: [WinError 1] Incorrect Function` error.